### PR TITLE
Fix shared mutable default in ConversionRequest

### DIFF
--- a/src/docs_to_md/storage/models.py
+++ b/src/docs_to_md/storage/models.py
@@ -48,7 +48,8 @@ class ConversionRequest(BaseModel):
     output_format: str = "markdown"
     status: Status = Status.PENDING
     error: Optional[str] = None
-    chunks: List[ChunkInfo] = []
+    # Use default_factory to avoid shared mutable list across instances
+    chunks: List[ChunkInfo] = Field(default_factory=list)
     chunk_size: int
     tmp_dir: Optional[Path] = None  # Directory for temporary files for this conversion
     images_dir: Optional[Path] = None  # Added to store determined image path


### PR DESCRIPTION
## Summary
- avoid shared list between ConversionRequest instances using `Field(default_factory=list)`

## Testing
- `python -m compileall -q src`
