### PR TITLE
Add unittest-based test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Guidelines
+
+- Always run `python -m unittest discover -s tests -v` before committing changes.
+- New tests should be added under the `tests/` directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,6 @@ pdf-to-md = "docs_to_md.main:main"
 # Just in case: Configure setuptools to find packages in src/
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[project.optional-dependencies]
+test = []

--- a/tests/filetype.py
+++ b/tests/filetype.py
@@ -1,0 +1,7 @@
+class Type:
+    def __init__(self, mime):
+        self.mime = mime
+
+
+def guess(_):
+    return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from docs_to_md.config.cli import create_config_from_args
+
+
+class TestCLI(unittest.TestCase):
+    def test_create_config_from_args(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            input_file = Path(tmp_dir) / "input.txt"
+            input_file.write_text("data")
+            env = {"MARKER_PDF_KEY": "abc"}
+            argv = [
+                "prog",
+                str(input_file),
+                "-cs",
+                "5",
+                "--max",
+                "-o",
+                tmp_dir,
+            ]
+            with mock.patch.dict(os.environ, env, clear=False):
+                with mock.patch.object(sys, "argv", argv):
+                    config = create_config_from_args()
+            self.assertEqual(config.input_path, str(input_file))
+            self.assertEqual(config.chunk_size, 5)
+            self.assertTrue(config.use_llm)
+            self.assertTrue(config.force_ocr)
+            self.assertEqual(config.output_dir, Path(tmp_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from docs_to_md.core.paths import determine_output_paths
+
+
+class TestPaths(unittest.TestCase):
+    def test_determine_output_paths_creates_base_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            input_file = tmp_path / "input.txt"
+            input_file.write_text("data")
+            out_dir = tmp_path / "out"
+            result = determine_output_paths(input_file, out_dir, "markdown")
+            self.assertEqual(result.markdown_path.parent, out_dir)
+            self.assertEqual(result.images_dir.parent, out_dir)
+            self.assertTrue(result.unique_key)
+            self.assertEqual(result.markdown_path.suffix, ".md")
+            self.assertTrue(out_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,65 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from docs_to_md.config.settings import Config
+from docs_to_md.utils.exceptions import ConfigurationError
+
+
+class TestSettings(unittest.TestCase):
+    def test_config_validation_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            test_file = tmp_path / "input.txt"
+            test_file.write_text("data")
+            cfg = Config(
+                api_key="key",
+                input_path=str(test_file),
+                output_dir=tmp_path,
+                output_format="markdown",
+            )
+            cfg.validate()
+
+    def test_config_missing_api_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            test_file = tmp_path / "in.txt"
+            test_file.write_text("x")
+            cfg = Config(
+                api_key="",
+                input_path=str(test_file),
+                output_dir=tmp_path,
+                output_format="markdown",
+            )
+            with self.assertRaises(ConfigurationError):
+                cfg.validate()
+
+    def test_config_nonexistent_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cfg = Config(
+                api_key="key",
+                input_path=str(tmp_path / "no.txt"),
+                output_dir=tmp_path,
+                output_format="markdown",
+            )
+            with self.assertRaises(ConfigurationError):
+                cfg.validate()
+
+    def test_config_relative_output_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            test_file = tmp_path / "file.txt"
+            test_file.write_text("x")
+            cfg = Config(
+                api_key="key",
+                input_path=str(test_file),
+                output_dir=Path("relative"),
+                output_format="markdown",
+            )
+            with self.assertRaises(ConfigurationError):
+                cfg.validate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from docs_to_md.utils.file_utils import get_unique_filename
+
+
+class TestFileUtils(unittest.TestCase):
+    def test_get_unique_filename(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            file_path = tmp_path / "file.txt"
+            file_path.write_text("data")
+            new_path = get_unique_filename(file_path)
+            self.assertNotEqual(new_path, file_path)
+            self.assertEqual(new_path.parent, file_path.parent)
+            self.assertTrue(new_path.stem.startswith("file_"))
+            self.assertEqual(new_path.suffix, ".txt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update repo guidelines to run `unittest`
- switch tests from pytest style to unittest
- stub minimal `filetype` module for tests
- clean optional test dependencies

## Testing
- `PYTHONPATH=src:tests python -m unittest discover -s tests -v`